### PR TITLE
Add Decoder Stage to CPU

### DIFF
--- a/build_frimware.sh
+++ b/build_frimware.sh
@@ -6,3 +6,7 @@ riscv64-unknown-elf-objcopy -O binary ./firmware/obj_dir/main.o ./firmware/obj_d
 riscv64-unknown-elf-as ./firmware/test.s -march=rv32i -o ./firmware/obj_dir/test.o -fPIC
 riscv64-unknown-elf-objcopy -O verilog ./firmware/obj_dir/test.o ./firmware/obj_dir/test.hex
 riscv64-unknown-elf-objcopy -O binary ./firmware/obj_dir/test.o ./firmware/obj_dir/test.bin
+
+riscv64-unknown-elf-as ./firmware/all.s -march=rv32i -o ./firmware/obj_dir/all.o -fPIC
+riscv64-unknown-elf-objcopy -O verilog ./firmware/obj_dir/all.o ./firmware/obj_dir/all.hex
+riscv64-unknown-elf-objcopy -O binary ./firmware/obj_dir/all.o ./firmware/obj_dir/all.bin

--- a/firmware/all.s
+++ b/firmware/all.s
@@ -1,0 +1,135 @@
+.section .text
+.global _start
+
+_start:
+    # Load upper immediate
+    lui x1, 0x1
+
+    # Add immediate
+    addi x2, x0, 10
+
+    # Store word
+    sw x2, 0(x1)
+
+    # Load word
+    lw x3, 0(x1)
+
+    # Add
+    add x4, x2, x3
+
+    # Subtract
+    sub x5, x4, x2
+
+    # Shift left logical
+    sll x6, x5, x2
+
+    # Set less than
+    slt x7, x6, x5
+
+    # Set less than unsigned
+    sltu x8, x7, x6
+
+    # XOR
+    xor x9, x8, x7
+
+    # Shift right logical
+    srl x10, x9, x8
+
+    # Shift right arithmetic
+    sra x11, x10, x9
+
+    # OR
+    or x12, x11, x10
+
+    # AND
+    and x13, x12, x11
+
+    # Branch equal
+    beq x13, x12, label_equal
+
+    # Branch not equal
+    bne x13, x11, label_not_equal
+
+label_equal:
+    # Jump and link
+    jal x14, label_jump
+
+label_not_equal:
+    # Jump and link register
+    jalr x15, 0(x14)
+
+label_jump:
+    # Branch less than
+    blt x15, x14, label_less_than
+
+    # Branch greater or equal
+    bge x15, x14, label_greater_or_equal
+
+label_less_than:
+    # Branch less than unsigned
+    bltu x15, x14, label_less_than_unsigned
+
+    # Branch greater or equal unsigned
+    bgeu x15, x14, label_greater_or_equal_unsigned
+
+label_less_than_unsigned:
+    # End of demo
+    nop
+
+label_greater_or_equal:
+    # Immediate AND
+    andi x16, x15, 0xF
+
+label_greater_or_equal_unsigned:
+    # Immediate OR
+    ori x17, x16, 0xF
+
+    # Immediate XOR
+    xori x18, x17, 0xF
+
+    # Immediate Shift Left Logical
+    slli x19, x18, 1
+
+    # Immediate Shift Right Logical
+    srli x20, x19, 1
+
+    # Immediate Shift Right Arithmetic
+    srai x21, x20, 1
+
+    # Fence instruction
+    fence
+
+    # Environment call
+    ecall
+
+    # Environment break
+    ebreak
+
+    # Unsigned Load Byte
+    lbu x22, 0(x1)
+
+    # Unsigned Load Halfword
+    lhu x23, 0(x1)
+
+    # Signed Load Byte
+    lb x24, 0(x1)
+
+    # Signed Load Halfword
+    lh x25, 0(x1)
+
+    # Store Byte
+    sb x22, 1(x1)
+
+    # Store Halfword
+    sh x23, 2(x1)
+
+    # Load Upper Immediate
+    lui x26, 0xFFFFF
+
+    # Add Upper Immediate to PC
+    auipc x27, 0xFFFFF
+
+    # Halt
+    j halt
+halt:
+    j halt

--- a/firmware/test.s
+++ b/firmware/test.s
@@ -1,7 +1,7 @@
 nop
+add x3, x3, -1
 add x0, x0, x0
-add x2, x2, 15
+add x2, x2, 0xFF
 add x1, x1, x1
-add x3, x3, 255
+add x1, x1, 0xF
 add x2, x2, x2
-nop

--- a/firmware/test.s
+++ b/firmware/test.s
@@ -1,1 +1,7 @@
-add x3, x0, 5 
+nop
+add x0, x0, x0
+add x2, x2, 15
+add x1, x1, x1
+add x3, x3, 255
+add x2, x2, x2
+nop

--- a/rtl/core.sv
+++ b/rtl/core.sv
@@ -31,7 +31,7 @@ wire invalid_instruction;
 
 wire valid_decoder_output;
 
-assign invalid_instruction = ~(|instruction) & ~valid_decoder_output;
+assign invalid_instruction = ~(|instruction) | ~valid_decoder_output;
 
 always_ff @(posedge clk)
     if(rst)

--- a/rtl/core.sv
+++ b/rtl/core.sv
@@ -25,28 +25,24 @@ module core #(
 
 reg [31:0] pc;
 
-
-
-always_ff @(posedge clk) 
-    if(rst) begin
-        pc <= 0;
-    end
+wire [31:0] instruction;
 
 wire invalid_instruction;
 
-assign invalid_instruction = ~(|instruction);
+wire valid_decoder_output;
+
+assign invalid_instruction = ~(|instruction) & ~valid_decoder_output;
 
 always_ff @(posedge clk)
-    if (clk_en)
+    if(rst)
+        pc <= 0;
+    else if (clk_en)
         if(~invalid_instruction)
             pc <= pc + 1;
         else
             $finish();
 
-wire [31:0] instruction;
-
-fetch  #(.ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH)) 
-    u_fetch(
+fetch #(.ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH)) u_fetch(
     .clk(clk),
     .clk_en(clk_en),
     .rst(rst),
@@ -57,6 +53,16 @@ fetch  #(.ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH))
     .i_read_fetch_data(i_read_fetch_data),
 
     .o_instruction(instruction)
+);
+
+decode u_decode(
+    .clk(clk),
+    .clk_en(clk_en),
+    .rst(rst),
+
+    .i_instruction(instruction),
+
+    .o_valid(valid_decoder_output)
 );
     
 endmodule

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -1,4 +1,6 @@
-typedef enum logic [2:0] {
+`timescale 1ns/1ps
+
+typedef enum bit [2:0] {
   ERROR,
   R,
   I,
@@ -15,6 +17,7 @@ module decode (
 
   input [31:0] i_instruction,
 
+  
   output logic [6:0] o_opcode,
   output logic [7:0] o_funct7,
   output logic [2:0] o_funct3,
@@ -26,107 +29,127 @@ module decode (
   output logic o_valid
 );
 
+  bit [6:0] opcode;
+  bit [7:0] funct7;
+  bit [2:0] funct3;
+  bit [4:0] rs1;
+  bit [4:0] rs2;
+  bit [4:0] rd;
+  bit [31:0] imm;
+
   inst_type_e inst_type;
 
-  assign o_valid = (|inst_type);
+  wire valid = (|inst_type);
+
+  wire no_output = rst | ~valid;
 
   //xxxxx11 = not compressed
 
-  wire no_output = rst | ~o_valid;
+  always_comb begin
+    unique case (i_instruction[6:0])
+      7'b0110011: inst_type = R;
+      7'b0010011: inst_type = I;
+      7'b0000011: inst_type = I;
+      7'b0100011: inst_type = S;
+      7'b1100011: inst_type = B;
+      7'b1101111: inst_type = J;
+      7'b1100111: inst_type = I;
+      7'b0110111: inst_type = U;
+      7'b0010111: inst_type = U;
+      7'b1110011: inst_type = I;
+      default: inst_type = ERROR;
+    endcase
+  end
+
+  always_comb begin
+    if (no_output) begin
+      funct7 = 0;
+      funct3 = 0;
+      rs1 = 0;
+      rs2 = 0;
+      rd = 0;
+      imm = 0;
+      opcode = 0;
+    end else begin
+      opcode = i_instruction[6:0];
+
+      unique case (inst_type)
+        R: begin
+          funct7 = i_instruction[31:25];
+          rs2 = i_instruction[24:20];
+          rs1 = i_instruction[19:15];
+          funct3 = i_instruction[14:12];
+          rd = i_instruction[11:7];
+
+          imm = 0;
+        end
+        I: begin
+          imm[11:0] = i_instruction[31:20];
+          rs1 = i_instruction[19:15];
+          funct3 = i_instruction[14:12];
+          rd = i_instruction[11:7];
+          
+          funct7 = 0;
+          rs2 = 0;
+        end
+        S: begin
+          imm[11:5] = i_instruction[31:25];
+          rs2 = i_instruction[24:20];
+          rs1 = i_instruction[19:15];
+          funct3 = i_instruction[14:12];
+          imm[4:0] = i_instruction[11:7];
+          
+          funct7 = 0;
+          rd = 0;
+        end
+        B: begin
+          imm[12] = i_instruction[31];
+          imm[10:5] = i_instruction[30:25];
+          rs2 = i_instruction[24:20];
+          rs1 = i_instruction[19:15];
+          funct3 = i_instruction[14:12];
+          imm[4:1] = i_instruction[11:8];
+          imm[11] = i_instruction[7];
+
+          funct7 = 0;
+          rd = 0;
+        end
+        U: begin
+          imm[31:12] = i_instruction[31:12];
+          rd = i_instruction[11:7];
+
+          funct7 = 0;
+          funct3 = 0;
+          rs1 = 0;
+          rs2 = 0;
+        end
+        J: begin
+          imm[20] = i_instruction[31];
+          imm[10:1] = i_instruction[30:21];
+          imm[11] = i_instruction[20];
+          imm[19:12] = i_instruction[19:12];
+          rd = i_instruction[11:7];
+
+          funct7 = 0;
+          funct3 = 0;
+          rs1 = 0;
+          rs2 = 0;
+        end
+      endcase
+    end
+  end
 
   always_ff @(posedge clk) begin
-    if (rst | ~(|inst_type)) begin 
-      o_funct7 = 0;
-      o_funct3 = 0;
-      o_rs1 = 0;
-      o_rs2 = 0;
-      o_rd = 0;
-      o_imm = 0;
-      o_opcode = 0;
-    end
-    
     if (clk_en) begin
-      unique case (i_instruction[6:0])
-        7'b0110011: inst_type = R;
-        7'b0010011: inst_type = I;
-        7'b0000011: inst_type = I;
-        7'b0100011: inst_type = S;
-        7'b1100011: inst_type = B;
-        7'b1101111: inst_type = J;
-        7'b1100111: inst_type = I;
-        7'b0110111: inst_type = U;
-        7'b0010111: inst_type = U;
-        7'b1110011: inst_type = I;
-        default: inst_type = ERROR;
-      endcase
-
-      if ((|inst_type)) begin
-        o_opcode = i_instruction[6:0];
-
-        case (inst_type)
-          R: begin
-            o_funct7 = i_instruction[31:25];
-            o_rs2 = i_instruction[24:20];
-            o_rs1 = i_instruction[19:15];
-            o_funct3 = i_instruction[14:12];
-            o_rd = i_instruction[11:7];
-
-            o_imm = 0;
-          end
-          I: begin
-            o_imm[11:0] = i_instruction[31:20];
-            o_rs1 = i_instruction[19:15];
-            o_funct3 = i_instruction[14:12];
-            o_rd = i_instruction[11:7];
-            
-            o_funct7 = 0;
-            o_rs2 = 0;
-          end
-          S: begin
-            o_imm[11:5] = i_instruction[31:25];
-            o_rs2 = i_instruction[24:20];
-            o_rs1 = i_instruction[19:15];
-            o_funct3 = i_instruction[14:12];
-            o_imm[4:0] = i_instruction[11:7];
-            
-            o_funct7 = 0;
-            o_rd = 0;
-          end
-          B: begin
-            o_imm[12] = i_instruction[31];
-            o_imm[10:5] = i_instruction[30:25];
-            o_rs2 = i_instruction[24:20];
-            o_rs1 = i_instruction[19:15];
-            o_funct3 = i_instruction[14:12];
-            o_imm[4:1] = i_instruction[11:8];
-            o_imm[11] = i_instruction[7];
-
-            o_funct7 = 0;
-            o_rd = 0;
-          end
-          U: begin
-            o_imm[31:12] = i_instruction[31:12];
-            o_rd = i_instruction[11:7];
-
-            o_funct7 = 0;
-            o_funct3 = 0;
-            o_rs1 = 0;
-            o_rs2 = 0;
-          end
-          J: begin
-            o_imm[20] = i_instruction[31];
-            o_imm[10:1] = i_instruction[30:21];
-            o_imm[11] = i_instruction[20];
-            o_imm[19:12] = i_instruction[19:12];
-            o_rd = i_instruction[11:7];
-
-            o_funct7 = 0;
-            o_funct3 = 0;
-            o_rs1 = 0;
-            o_rs2 = 0;
-          end
-        endcase
-      end
+      o_valid <= valid;
+      
+      o_funct7 <= funct7;
+      o_funct3 <= funct3;
+      o_rs1 <= rs1;
+      o_rs2 <= rs2;
+      o_rd <= rd;
+      o_imm <= imm;
+      o_opcode <= opcode;
 
       $display("Instruction Type: %0h", inst_type);
     end

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -16,32 +16,21 @@ module decode (
   input rst,
 
   input [31:0] i_instruction,
-
   
-  output logic [6:0] o_opcode,
-  output logic [7:0] o_funct7,
-  output logic [2:0] o_funct3,
-  output logic [4:0] o_rs1,
-  output logic [4:0] o_rs2,
-  output logic [4:0] o_rd,
-  output logic [31:0] o_imm,
+  output bit [6:0] o_opcode,
+  output bit [7:0] o_funct7,
+  output bit [2:0] o_funct3,
+  output bit [4:0] o_rs1,
+  output bit [4:0] o_rs2,
+  output bit [4:0] o_rd,
+  output bit [31:0] o_imm,
 
-  output logic o_valid
+  output bit o_valid
 );
-
-  bit [6:0] opcode;
-  bit [7:0] funct7;
-  bit [2:0] funct3;
-  bit [4:0] rs1;
-  bit [4:0] rs2;
-  bit [4:0] rd;
-  bit [31:0] imm;
 
   inst_type_e inst_type;
 
-  wire valid = (|inst_type);
-
-  wire no_output = rst | ~valid;
+  wire no_output = rst | ~o_valid;
 
   //xxxxx11 = not compressed
 
@@ -59,99 +48,85 @@ module decode (
       7'b1110011: inst_type = I;
       default: inst_type = ERROR;
     endcase
+
+    o_valid = (|inst_type);
   end
 
   always_comb begin
     if (no_output) begin
-      funct7 = 0;
-      funct3 = 0;
-      rs1 = 0;
-      rs2 = 0;
-      rd = 0;
-      imm = 0;
-      opcode = 0;
+      o_funct7 = 0;
+      o_funct3 = 0;
+      o_rs1 = 0;
+      o_rs2 = 0;
+      o_rd = 0;
+      o_imm = 0;
+      o_opcode = 0;
     end else begin
-      opcode = i_instruction[6:0];
+      o_opcode = i_instruction[6:0];
 
       unique case (inst_type)
         R: begin
-          funct7 = i_instruction[31:25];
-          rs2 = i_instruction[24:20];
-          rs1 = i_instruction[19:15];
-          funct3 = i_instruction[14:12];
-          rd = i_instruction[11:7];
+          o_funct7 = i_instruction[31:25];
+          o_rs2 = i_instruction[24:20];
+          o_rs1 = i_instruction[19:15];
+          o_funct3 = i_instruction[14:12];
+          o_rd = i_instruction[11:7];
 
-          imm = 0;
+          o_imm = 0;
         end
         I: begin
-          imm[11:0] = i_instruction[31:20];
-          rs1 = i_instruction[19:15];
-          funct3 = i_instruction[14:12];
-          rd = i_instruction[11:7];
+          o_imm[11:0] = i_instruction[31:20];
+          o_rs1 = i_instruction[19:15];
+          o_funct3 = i_instruction[14:12];
+          o_rd = i_instruction[11:7];
           
-          funct7 = 0;
-          rs2 = 0;
+          o_funct7 = 0;
+          o_rs2 = 0;
         end
         S: begin
-          imm[11:5] = i_instruction[31:25];
-          rs2 = i_instruction[24:20];
-          rs1 = i_instruction[19:15];
-          funct3 = i_instruction[14:12];
-          imm[4:0] = i_instruction[11:7];
+          o_imm[11:5] = i_instruction[31:25];
+          o_rs2 = i_instruction[24:20];
+          o_rs1 = i_instruction[19:15];
+          o_funct3 = i_instruction[14:12];
+          o_imm[4:0] = i_instruction[11:7];
           
-          funct7 = 0;
-          rd = 0;
+          o_funct7 = 0;
+          o_rd = 0;
         end
         B: begin
-          imm[12] = i_instruction[31];
-          imm[10:5] = i_instruction[30:25];
-          rs2 = i_instruction[24:20];
-          rs1 = i_instruction[19:15];
-          funct3 = i_instruction[14:12];
-          imm[4:1] = i_instruction[11:8];
-          imm[11] = i_instruction[7];
+          o_imm[12] = i_instruction[31];
+          o_imm[10:5] = i_instruction[30:25];
+          o_rs2 = i_instruction[24:20];
+          o_rs1 = i_instruction[19:15];
+          o_funct3 = i_instruction[14:12];
+          o_imm[4:1] = i_instruction[11:8];
+          o_imm[11] = i_instruction[7];
 
-          funct7 = 0;
-          rd = 0;
+          o_funct7 = 0;
+          o_rd = 0;
         end
         U: begin
-          imm[31:12] = i_instruction[31:12];
-          rd = i_instruction[11:7];
+          o_imm[31:12] = i_instruction[31:12];
+          o_rd = i_instruction[11:7];
 
-          funct7 = 0;
-          funct3 = 0;
-          rs1 = 0;
-          rs2 = 0;
+          o_funct7 = 0;
+          o_funct3 = 0;
+          o_rs1 = 0;
+          o_rs2 = 0;
         end
         J: begin
-          imm[20] = i_instruction[31];
-          imm[10:1] = i_instruction[30:21];
-          imm[11] = i_instruction[20];
-          imm[19:12] = i_instruction[19:12];
-          rd = i_instruction[11:7];
+          o_imm[20] = i_instruction[31];
+          o_imm[10:1] = i_instruction[30:21];
+          o_imm[11] = i_instruction[20];
+          o_imm[19:12] = i_instruction[19:12];
+          o_rd = i_instruction[11:7];
 
-          funct7 = 0;
-          funct3 = 0;
-          rs1 = 0;
-          rs2 = 0;
+          o_funct7 = 0;
+          o_funct3 = 0;
+          o_rs1 = 0;
+          o_rs2 = 0;
         end
       endcase
-    end
-  end
-
-  always_ff @(posedge clk) begin
-    if (clk_en) begin
-      o_valid <= valid;
-      
-      o_funct7 <= funct7;
-      o_funct3 <= funct3;
-      o_rs1 <= rs1;
-      o_rs2 <= rs2;
-      o_rd <= rd;
-      o_imm <= imm;
-      o_opcode <= opcode;
-
-      $display("Instruction Type: %0h", inst_type);
     end
   end
 

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -1,0 +1,135 @@
+typedef enum logic [2:0] {
+  ERROR,
+  R,
+  I,
+  S,
+  B,
+  U,
+  J
+} inst_type_e;
+
+module decode (
+  input clk,
+  input clk_en,
+  input rst,
+
+  input [31:0] i_instruction,
+
+  output logic [6:0] o_opcode,
+  output logic [7:0] o_funct7,
+  output logic [2:0] o_funct3,
+  output logic [4:0] o_rs1,
+  output logic [4:0] o_rs2,
+  output logic [4:0] o_rd,
+  output logic [31:0] o_imm,
+
+  output logic o_valid
+);
+
+  inst_type_e inst_type;
+
+  assign o_valid = (|inst_type);
+
+  //xxxxx11 = not compressed
+
+  wire no_output = rst | ~o_valid;
+
+  always_ff @(posedge clk) begin
+    if (rst | ~(|inst_type)) begin 
+      o_funct7 = 0;
+      o_funct3 = 0;
+      o_rs1 = 0;
+      o_rs2 = 0;
+      o_rd = 0;
+      o_imm = 0;
+      o_opcode = 0;
+    end
+    
+    if (clk_en) begin
+      unique case (i_instruction[6:0])
+        7'b0110011: inst_type = R;
+        7'b0010011: inst_type = I;
+        7'b0000011: inst_type = I;
+        7'b0100011: inst_type = S;
+        7'b1100011: inst_type = B;
+        7'b1101111: inst_type = J;
+        7'b1100111: inst_type = I;
+        7'b0110111: inst_type = U;
+        7'b0010111: inst_type = U;
+        7'b1110011: inst_type = I;
+        default: inst_type = ERROR;
+      endcase
+
+      if ((|inst_type)) begin
+        o_opcode = i_instruction[6:0];
+
+        case (inst_type)
+          R: begin
+            o_funct7 = i_instruction[31:25];
+            o_rs2 = i_instruction[24:20];
+            o_rs1 = i_instruction[19:15];
+            o_funct3 = i_instruction[14:12];
+            o_rd = i_instruction[11:7];
+
+            o_imm = 0;
+          end
+          I: begin
+            o_imm[11:0] = i_instruction[31:20];
+            o_rs1 = i_instruction[19:15];
+            o_funct3 = i_instruction[14:12];
+            o_rd = i_instruction[11:7];
+            
+            o_funct7 = 0;
+            o_rs2 = 0;
+          end
+          S: begin
+            o_imm[11:5] = i_instruction[31:25];
+            o_rs2 = i_instruction[24:20];
+            o_rs1 = i_instruction[19:15];
+            o_funct3 = i_instruction[14:12];
+            o_imm[4:0] = i_instruction[11:7];
+            
+            o_funct7 = 0;
+            o_rd = 0;
+          end
+          B: begin
+            o_imm[12] = i_instruction[31];
+            o_imm[10:5] = i_instruction[30:25];
+            o_rs2 = i_instruction[24:20];
+            o_rs1 = i_instruction[19:15];
+            o_funct3 = i_instruction[14:12];
+            o_imm[4:1] = i_instruction[11:8];
+            o_imm[11] = i_instruction[7];
+
+            o_funct7 = 0;
+            o_rd = 0;
+          end
+          U: begin
+            o_imm[31:12] = i_instruction[31:12];
+            o_rd = i_instruction[11:7];
+
+            o_funct7 = 0;
+            o_funct3 = 0;
+            o_rs1 = 0;
+            o_rs2 = 0;
+          end
+          J: begin
+            o_imm[20] = i_instruction[31];
+            o_imm[10:1] = i_instruction[30:21];
+            o_imm[11] = i_instruction[20];
+            o_imm[19:12] = i_instruction[19:12];
+            o_rd = i_instruction[11:7];
+
+            o_funct7 = 0;
+            o_funct3 = 0;
+            o_rs1 = 0;
+            o_rs2 = 0;
+          end
+        endcase
+      end
+
+      $display("Instruction Type: %0h", inst_type);
+    end
+  end
+
+endmodule

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -3,7 +3,7 @@
 module fetch #(
     ADDR_WIDTH = 31,
     DATA_WIDTH = 31
-)(
+) (
     input clk,
     input clk_en,
     input rst,
@@ -20,5 +20,6 @@ module fetch #(
     assign o_read_fetch_addr = i_pc;
 
     always_ff @(posedge clk)
-            o_instruction <= i_read_fetch_data;
+        o_instruction <= i_read_fetch_data;
+
 endmodule

--- a/run/main.cpp
+++ b/run/main.cpp
@@ -2,6 +2,7 @@
 #include "verilated.h"
 #include "verilated_fst_c.h"
 #include "uartsim.h"
+#include <cstdio>
 Vrv32i *top;
 VerilatedContext *contextp;
 VerilatedFstC *tfp;
@@ -72,19 +73,12 @@ int main(int argc, char **argv) {
 
   tfp->open("run.fst");
   while (!contextp->gotFinish()) {
-  //for (int i = 0; i < 10; i++) {
-        contextp->timeInc(1);
-
-    	  top->clk = 1;
-				top->eval();
-        tfp->dump(contextp->time());
-
-        contextp->timeInc(1);
-				top->clk = 0;
-				top->eval();
-        tfp->dump(contextp->time());
-
+    	  top->clk = !top->clk;
         top->rx = (*uart)(top->tx);
+
+				top->eval();
+        tfp->dump(contextp->time());
+        contextp->timeInc(1);
   }
 
   tfp->close();


### PR DESCRIPTION
# Pull Request Summary

This pull request enhances the firmware and core RTL code to improve testing coverage and prepare for expanded instruction decoding capabilities. Key updates include adding a comprehensive RISC-V assembly test file, modifying the build script to assemble new firmware, updating an existing test assembly file, and adjusting the core module to incorporate instruction validity checks and decoding.

## Changes

1. **Update `build_frimware.sh`:**

   - **Added Build Commands for New Firmware `all.s`:**
     - Assembles `all.s` into an object file `all.o`.
     - Converts `all.o` into Verilog hex format `all.hex` for simulation.
     - Converts `all.o` into a binary file `all.bin` for potential loading or flashing.

     ```diff
     +riscv64-unknown-elf-as ./firmware/all.s -march=rv32i -o ./firmware/obj_dir/all.o -fPIC
     +riscv64-unknown-elf-objcopy -O verilog ./firmware/obj_dir/all.o ./firmware/obj_dir/all.hex
     +riscv64-unknown-elf-objcopy -O binary ./firmware/obj_dir/all.o ./firmware/obj_dir/all.bin
     ```

2. **Add New Firmware Assembly File `all.s`:**

   - **Purpose:** Provides an extensive set of RISC-V instructions covering arithmetic, logical, control flow, and memory operations for thorough testing of the processor core.

   - **Highlights of `all.s`:**

     - **Arithmetic Instructions:**
       - `add`, `addi`, `sub`, `lui`, `auipc`
     - **Logical Instructions:**
       - `and`, `andi`, `or`, `ori`, `xor`, `xori`
     - **Shift Instructions:**
       - `sll`, `slli`, `srl`, `srli`, `sra`, `srai`
     - **Set Instructions:**
       - `slt`, `sltu`
     - **Branch Instructions:**
       - `beq`, `bne`, `blt`, `bge`, `bltu`, `bgeu`
     - **Jump Instructions:**
       - `jal`, `jalr`
     - **Memory Instructions:**
       - `lw`, `sw`, `lb`, `lbu`, `lh`, `lhu`, `sb`, `sh`
     - **System Instructions:**
       - `fence`, `ecall`, `ebreak`
     - **Labels and Control Flow:**
       - Utilizes labels for branching and jumping to test control flow mechanisms.

<details>
<summary>Test File Code</summary>

```assembly
.section .text
.global _start

_start:
   # Load upper immediate
   lui x1, 0x1

   # Add immediate
   addi x2, x0, 10

   # Store word
   sw x2, 0(x1)

   # Load word
   lw x3, 0(x1)

   # Add
   add x4, x2, x3

   # Subtract
   sub x5, x4, x2

   # Shift left logical
   sll x6, x5, x2

   # Set less than
   slt x7, x6, x5

   # Set less than unsigned
   sltu x8, x7, x6

   # XOR
   xor x9, x8, x7

   # Shift right logical
   srl x10, x9, x8

   # Shift right arithmetic
   sra x11, x10, x9

   # OR
   or x12, x11, x10

   # AND
   and x13, x12, x11

   # Branch equal
   beq x13, x12, label_equal

   # Branch not equal
   bne x13, x11, label_not_equal

label_equal:
   # Jump and link
   jal x14, label_jump

label_not_equal:
   # Jump and link register
   jalr x15, 0(x14)

label_jump:
   # Branch less than
   blt x15, x14, label_less_than

   # Branch greater or equal
   bge x15, x14, label_greater_or_equal

label_less_than:
   # Branch less than unsigned
   bltu x15, x14, label_less_than_unsigned

   # Branch greater or equal unsigned
   bgeu x15, x14, label_greater_or_equal_unsigned

label_less_than_unsigned:
   # End of demo
   nop

label_greater_or_equal:
   # Immediate AND
   andi x16, x15, 0xF

label_greater_or_equal_unsigned:
   # Immediate OR
   ori x17, x16, 0xF

   # Immediate XOR
   xori x18, x17, 0xF

   # Immediate Shift Left Logical
   slli x19, x18, 1

   # Immediate Shift Right Logical
   srli x20, x19, 1

   # Immediate Shift Right Arithmetic
   srai x21, x20, 1

   # Fence instruction
   fence

   # Environment call
   ecall

   # Environment break
   ebreak

   # Unsigned Load Byte
   lbu x22, 0(x1)

   # Unsigned Load Halfword
   lhu x23, 0(x1)

   # Signed Load Byte
   lb x24, 0(x1)

   # Signed Load Halfword
   lh x25, 0(x1)

   # Store Byte
   sb x22, 1(x1)

   # Store Halfword
   sh x23, 2(x1)

   # Load Upper Immediate
   lui x26, 0xFFFFF

   # Add Upper Immediate to PC
   auipc x27, 0xFFFFF

   # Halt
   j halt
halt:
   j halt
```

</details>

3. **Update `firmware/test.s`:**

   - **Expanded Test Instructions:**
     - Added multiple `add` and `nop` instructions to enhance the basic test suite.

     ```diff
     -add x3, x0, 5
     +nop
     +add x3, x3, -1
     +add x0, x0, x0
     +add x2, x2, 0xFF
     +add x1, x1, x1
     +add x1, x1, 0xF
     +add x2, x2, x2
     ```

4. **Modify `rtl/core.sv`:**

   - **Adjustments in the `core` Module:**

     - **Introduced `valid_decoder_output` Signal:**
       - A wire `valid_decoder_output` is added to represent the validity of the decoded instruction from the `decode` module.

       ```verilog
       wire valid_decoder_output;
       ```

     - **Updated `invalid_instruction` Logic:**
       - The `invalid_instruction` signal now accounts for both an all-zero instruction and an invalid decoder output.

       ```verilog
       assign invalid_instruction = ~(|instruction) | ~valid_decoder_output;
       ```

     - **Program Counter (`pc`) Handling Accounts for Decode Errors:**
       - On reset (`rst`), the program counter `pc` is reset to `0`.
       - During normal operation, if `clk_en` is asserted:
         - If the instruction is valid and could be decoded, increment `pc`.
         - If invalid, terminate the simulation using `$finish()`.

       ```verilog
       always_ff @(posedge clk)
           if (rst)
               pc <= 0;
           else if (clk_en)
               if (~invalid_instruction)
                   pc <= pc + 1;
               else
                   $finish();
       ```

     - **Reorganized Code for Clarity:**
       - Moved the declaration of `instruction` wire to the top for better readability.

     - **Added Instantiation of `decode` Module:**
       - Prepared the core for future stages by instantiating the `decode` module.

---

These updates significantly enhance the testing framework and core processor functionality:

- **Comprehensive Testing:** The new `all.s` assembly file provides extensive coverage of RISC-V instructions, enabling thorough validation of the processor's instruction handling.
- **Improved Core Logic:** Adjustments to the `core.sv` module prepare the design for integrating instruction decoding and enhance the control flow for handling invalid instructions.
- **Enhanced Build Process:** Modifications to `build_frimware.sh` streamline the firmware compilation process, ensuring that new test programs are correctly assembled and formatted for simulation.

---

**Note:** The `decode` module is instantiated but not yet connected to anything. The simulation stops when the instruction is all 0s, or the decoder cannot decode the instruction type.